### PR TITLE
Fixes build against rustc 0.13.0-nightly cc19e3380 2014-12-20

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ fn expand_link_config(ecx: &mut ExtCtxt, span: Span,
                       tts: &[ast::TokenTree]) -> Box<MacResult+'static> {
     macro_rules! try_dummy( ($e:expr) => (
         match $e { Ok(s) => s, Err(()) => return DummyResult::any(span) }
-    ) )
+    ) );
 
     let mut parser = ecx.new_parser_from_tts(tts);
     let (pkg, sp) = try_dummy!(parse_string(ecx, &mut parser));


### PR DESCRIPTION
- Adds a semi-colon to the `try_dummy` macro as required with the latest rust nightly.
