### PR TITLE
Fix build against rustc 1.0.0-nightly (44a287e6e 2015-01-08 17:03:40)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(plugin_registrar)]
+#![feature(plugin_registrar, box_syntax)]
 
 extern crate rustc;
 extern crate rustc_driver;


### PR DESCRIPTION
Hello, apparently box_syntax is needed to use box.