### PR TITLE
Fixes build against rustc 1.0.0-nightly (4be79d6ac 2015-01-23 16:08:14)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,6 @@ fn block(ecx: &mut ExtCtxt, sp: Span, info: &LibInfo,
     ecx.item(sp, special_idents::invalid, attrs.collect(),
              ast::ItemForeignMod(ast::ForeignMod {
         abi: abi::C,
-        view_items: Vec::new(),
         items: Vec::new(),
     }))
 }


### PR DESCRIPTION
Looks like `view_items` has been removed from `ForeignMod`.